### PR TITLE
Add Flutter RTP streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-INIT
+# Simple RTP Streamer
+
+This Flutter application provides a basic interface to start an RTP (H264) video stream using an external `ffmpeg` executable. It contains two input fields for the target IP address and port. Both values are required before streaming.
+
+## Usage
+
+1. Install [Flutter](https://flutter.dev/docs/get-started/install) on your machine.
+2. Ensure `ffmpeg` is available in your system `PATH` (for Windows you can install a pre-built package from [ffmpeg.org](https://ffmpeg.org/download.html)).
+3. Update the camera device name in `lib/main.dart` (`video=Integrated Camera`) if needed.
+4. Run the application with `flutter run`.
+
+Press the **Start Stream** button to begin streaming to the provided IP and port. The stream uses the command:
+
+```bash
+ffmpeg -f dshow -i video=<YOUR_CAMERA> -vcodec libx264 -f rtp rtp://<IP>:<PORT>
+```
+
+Press **Stop Stream** to terminate the process.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'RTP Streamer',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const StreamPage(),
+    );
+  }
+}
+
+class StreamPage extends StatefulWidget {
+  const StreamPage({super.key});
+
+  @override
+  State<StreamPage> createState() => _StreamPageState();
+}
+
+class _StreamPageState extends State<StreamPage> {
+  final TextEditingController _ipController = TextEditingController();
+  final TextEditingController _portController = TextEditingController();
+  Process? _ffmpegProcess;
+
+  bool get _isStreaming => _ffmpegProcess != null;
+
+  Future<void> _startStream() async {
+    final ip = _ipController.text.trim();
+    final port = _portController.text.trim();
+    if (ip.isEmpty || port.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Target IP and port are required')),
+      );
+      return;
+    }
+
+    final args = [
+      '-f',
+      'dshow',
+      '-i',
+      'video=Integrated Camera', // Change device name as needed
+      '-vcodec',
+      'libx264',
+      '-f',
+      'rtp',
+      'rtp://$ip:$port',
+    ];
+
+    try {
+      final process = await Process.start('ffmpeg', args);
+      setState(() {
+        _ffmpegProcess = process;
+      });
+
+      process.stderr.transform(utf8.decoder).listen((data) {
+        debugPrint(data);
+      });
+      process.stdout.transform(utf8.decoder).listen((data) {
+        debugPrint(data);
+      });
+      process.exitCode.then((_) {
+        if (mounted) {
+          setState(() {
+            _ffmpegProcess = null;
+          });
+        }
+      });
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to start ffmpeg: $e')),
+      );
+    }
+  }
+
+  void _stopStream() {
+    _ffmpegProcess?.kill(ProcessSignal.sigterm);
+    setState(() {
+      _ffmpegProcess = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('RTP H264 Streamer')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _ipController,
+              decoration: const InputDecoration(labelText: 'Target IP'),
+            ),
+            TextField(
+              controller: _portController,
+              decoration: const InputDecoration(labelText: 'Target Port'),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _isStreaming ? _stopStream : _startStream,
+              child: Text(_isStreaming ? 'Stop Stream' : 'Start Stream'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: rtp_streamer
+description: Simple RTP H264 streaming app
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- implement basic Flutter app with two input fields for IP and port
- start/stop button uses `ffmpeg` to stream H264 via RTP
- add `pubspec.yaml` and project instructions in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bfb24f4c0832b85741eb66b95331c