### PR TITLE
Fix build by adding FFmpeg repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,34 @@ Follow these steps if you are new to Flutter and this project:
 1. **Install Flutter** – Download and set up Flutter from the [official installation guide](https://flutter.dev/docs/get-started/install) for your operating system.
 2. **Clone this repository** – `git clone <REPO_URL>` and change into the project directory.
 3. **Fetch dependencies** – Run `flutter pub get` to install the required Dart packages.
-4. **Add ffmpeg_kit_flutter** – This package bundles FFmpeg for mobile. Add `ffmpeg_kit_flutter: ^6.0.3` to your `pubspec.yaml` and run `flutter pub get`.
-5. **Update the camera device name or input** – Edit `lib/main.dart` and adjust the input device. For Android or iOS you may need to specify `android_camera` or `avfoundation` instead of `dshow`.
-6. **Run the app** – Connect a device or start an emulator and execute `flutter run` from the project root.
+4. **Add ffmpeg_kit_flutter** – This package bundles FFmpeg for mobile. Add
+   `ffmpeg_kit_flutter: ^6.0.3` to your `pubspec.yaml` and run `flutter pub get`.
+   Gradle also needs to know where to fetch the FFmpeg artifacts. Edit
+   `android/build.gradle.kts` and add the FFmpeg Kit Maven repository:
+
+   ```kotlin
+   allprojects {
+       repositories {
+           google()
+           mavenCentral()
+           maven { url = uri("https://packages.tanersener.com/ffmpeg-kit/v6") }
+       }
+   }
+   ```
+
+   The `ffmpeg_kit_flutter` plugin expects Android NDK `27.0.12077973`, so
+   ensure your `android/app/build.gradle.kts` contains:
+
+   ```kotlin
+   android {
+       ndkVersion = "27.0.12077973"
+   }
+   ```
+5. **Update the camera device name or input** – Edit `lib/main.dart` and adjust
+   the input device. For Android or iOS you may need to specify `android_camera`
+   or `avfoundation` instead of `dshow`.
+6. **Run the app** – Connect a device or start an emulator and execute
+   `flutter run` from the project root.
 
 ## Usage
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://packages.tanersener.com/ffmpeg-kit/v6") }
     }
 }
 


### PR DESCRIPTION
## Summary
- update Gradle build script to include FFmpeg Kit repository
- explain repository setup and NDK requirement in README

## Testing
- `flutter pub get`
- `gradle -q tasks` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c35937cd4832b806fc34bf6888507