### PR TITLE
Fix FFmpegKit gradle configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,9 +43,17 @@ flutter {
     source = "../.."
 }
 
+repositories {
+    google()
+    mavenCentral()
+    flatDir {
+        dirs("../../app/libs")
+    }
+}
+
 dependencies {
-    implementation(name: 'ffmpeg-kit', ext: 'aar')
+    implementation(files("../../app/libs/ffmpeg-kit.aar"))
 
     // If needed:
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation("androidx.multidex:multidex:2.0.1")
 }


### PR DESCRIPTION
## Summary
- fix `ffmpeg-kit` Gradle dependency syntax for Kotlin DSL
- add repositories block to point to local aar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ad96c7c4832bade84d0aac199dcf