### PR TITLE
Fix permission handling and add iOS camera descriptions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,13 +4,13 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  PermissionsAndroid,
-  Platform,
   Alert,
 } from 'react-native'
 import { Camera, useCameraDevices } from 'react-native-vision-camera'
 import { FFmpegKit } from 'ffmpeg-kit-react-native'
 import type { CameraPermissionStatus } from 'react-native-vision-camera'
+
+const STREAM_URL = 'rtp://192.168.1.5:1234'
 
 export default function App() {
   const [hasPermission, setHasPermission] = useState<boolean>(false)
@@ -23,21 +23,9 @@ export default function App() {
       const cameraPermission: CameraPermissionStatus = await Camera.requestCameraPermission()
       const micPermission: CameraPermissionStatus = await Camera.requestMicrophonePermission()
 
-      if (Platform.OS === 'android') {
-        const storagePermission = await PermissionsAndroid.request(
-          PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
-        )
-
-        setHasPermission(
-          cameraPermission === 'granted' &&
-            micPermission === 'granted' &&
-            storagePermission === PermissionsAndroid.RESULTS.GRANTED,
-        )
-      } else {
-        setHasPermission(
-          cameraPermission === 'granted' && micPermission === 'granted',
-        )
-      }
+      setHasPermission(
+        cameraPermission === 'granted' && micPermission === 'granted',
+      )
     })()
   }, [])
 
@@ -45,7 +33,7 @@ export default function App() {
     setIsStreaming(true)
 
     // 🧪 Test source — replace with camera stream later
-    const command = `-f lavfi -i testsrc=size=640x480:rate=25 -vcodec libx264 -f rtp rtp://192.168.1.5:1234`
+    const command = `-f lavfi -i testsrc=size=640x480:rate=25 -vcodec libx264 -f rtp ${STREAM_URL}`
 
     FFmpegKit.executeAsync(command, async (session) => {
       const returnCode = await session.getReturnCode()

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -6,6 +6,20 @@ import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import App from '../App';
 
+jest.mock('react-native-vision-camera', () => {
+  const Camera = () => null
+  Camera.requestCameraPermission = jest.fn(() => Promise.resolve('granted'))
+  Camera.requestMicrophonePermission = jest.fn(() => Promise.resolve('granted'))
+  return {
+    Camera,
+    useCameraDevices: () => [{ position: 'back' }],
+  }
+})
+
+jest.mock('ffmpeg-kit-react-native', () => ({
+  FFmpegKit: { executeAsync: jest.fn() },
+}))
+
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {
     ReactTestRenderer.create(<App />);

--- a/ios/RTPStreamer/Info.plist
+++ b/ios/RTPStreamer/Info.plist
@@ -32,10 +32,14 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string></string>
+        <key>NSCameraUsageDescription</key>
+        <string>This app requires access to the camera to stream video.</string>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>This app requires access to the microphone for streaming.</string>
+        <key>UILaunchStoryboardName</key>
+        <string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
## Summary
- fix camera permission checks
- add streaming url constant
- mock native modules in tests
- document camera permission on iOS

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853e453a998832bb7894b2aaa217f41