### PR TITLE
Add logs and improve permission handling

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -10,6 +10,7 @@ jest.mock('react-native-vision-camera', () => {
   const Camera = () => null
   Camera.requestCameraPermission = jest.fn(() => Promise.resolve('granted'))
   Camera.requestMicrophonePermission = jest.fn(() => Promise.resolve('granted'))
+  Camera.getAvailableCameraDevices = jest.fn(() => [{ position: 'back' }])
   return {
     Camera,
     useCameraDevices: () => [{ position: 'back' }],


### PR DESCRIPTION
## Summary
- show camera and microphone permission statuses in logs
- log available devices
- clarify UI when permissions or devices are missing
- mock `Camera.getAvailableCameraDevices` in test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853e6934694832b85ba81c5f712d29c