### PR TITLE
Replace ffmpeg test stream with native camera RTP module

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,13 +4,13 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  Alert,
   PermissionsAndroid,
+  NativeModules,
 } from 'react-native'
 import { Camera, useCameraDevices } from 'react-native-vision-camera'
-import { FFmpegKit } from 'ffmpeg-kit-react-native'
 
-const STREAM_URL = 'http://192.168.1.103:5002'
+const { CameraStreamer } = NativeModules
+
 
 export default function App() {
   const [hasPermission, setHasPermission] = useState<boolean>(false)
@@ -59,30 +59,12 @@ export default function App() {
 
   const startStreaming = async () => {
     setIsStreaming(true)
+    CameraStreamer.startStreaming()
+  }
 
-    // 🧪 Test source — replace with camera stream later
-    const command = `-f lavfi -i testsrc=size=640x480:rate=25 -vcodec libx264 -f rtp ${STREAM_URL}`
-
-    console.log(`Starting FFmpeg streaming to ${STREAM_URL}`)
-
-    FFmpegKit.executeAsync(
-      command,
-      async (session) => {
-        const returnCode = await session.getReturnCode()
-        setIsStreaming(false)
-
-        if (returnCode?.isValueSuccess()) {
-          console.log('FFmpeg streaming finished successfully')
-          Alert.alert('Streaming ended', 'RTP stream finished successfully.')
-        } else {
-          console.log(`FFmpeg streaming failed with return code ${returnCode?.getValue()}`)
-          Alert.alert('Error', 'FFmpeg streaming failed.')
-        }
-      },
-      (log) => {
-        console.log('ffmpeg:', log.getMessage())
-      },
-    )
+  const stopStreaming = () => {
+    CameraStreamer.stopStreaming()
+    setIsStreaming(false)
   }
 
   if (!hasPermission) {
@@ -112,6 +94,13 @@ export default function App() {
         <Text style={styles.buttonText}>
           {isStreaming ? 'Streaming...' : 'Start Streaming'}
         </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[styles.button, !isStreaming && styles.buttonDisabled]}
+        onPress={stopStreaming}
+        disabled={!isStreaming}
+      >
+        <Text style={styles.buttonText}>Stop Streaming</Text>
       </TouchableOpacity>
     </View>
   )

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -26,13 +26,15 @@ jest.mock('react-native', () => {
     Text: 'Text',
     StyleSheet: { create: () => ({}) },
     TouchableOpacity: 'TouchableOpacity',
-    Alert: { alert: jest.fn() },
+    NativeModules: {
+      CameraStreamer: {
+        startStreaming: jest.fn(),
+        stopStreaming: jest.fn(),
+      },
+    },
   }
 })
 
-jest.mock('ffmpeg-kit-react-native', () => ({
-  FFmpegKit: { executeAsync: jest.fn() },
-}))
 
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
       android:name=".MainApplication"

--- a/android/app/src/main/java/com/rtpstreamer/CameraStreamerModule.kt
+++ b/android/app/src/main/java/com/rtpstreamer/CameraStreamerModule.kt
@@ -1,0 +1,113 @@
+package com.rtpstreamer
+
+import android.content.Context
+import android.hardware.camera2.*
+import android.media.MediaRecorder
+import android.os.Handler
+import android.os.HandlerThread
+import com.facebook.react.bridge.*
+
+class CameraStreamerModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+    private var cameraDevice: CameraDevice? = null
+    private var captureSession: CameraCaptureSession? = null
+    private var mediaRecorder: MediaRecorder? = null
+    private var backgroundThread: HandlerThread? = null
+    private var backgroundHandler: Handler? = null
+
+    override fun getName() = "CameraStreamer"
+
+    @ReactMethod
+    fun startStreaming(promise: Promise) {
+        val activity = currentActivity ?: run {
+            promise.reject("NO_ACTIVITY", "Current activity is null")
+            return
+        }
+        val manager = activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        try {
+            val cameraId = manager.cameraIdList.firstOrNull() ?: run {
+                promise.reject("NO_CAMERA", "No camera found")
+                return
+            }
+
+            startBackgroundThread()
+
+            mediaRecorder = MediaRecorder().apply {
+                setVideoSource(MediaRecorder.VideoSource.SURFACE)
+                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                setVideoEncoder(MediaRecorder.VideoEncoder.H264)
+                setVideoSize(640, 480)
+                setVideoFrameRate(30)
+                setVideoEncodingBitRate(1_000_000)
+                setOutputFile("rtp://192.168.1.103:5002")
+                prepare()
+            }
+
+            val surface = mediaRecorder!!.surface
+
+            manager.openCamera(cameraId, object : CameraDevice.StateCallback() {
+                override fun onOpened(device: CameraDevice) {
+                    cameraDevice = device
+                    device.createCaptureSession(listOf(surface), object : CameraCaptureSession.StateCallback() {
+                        override fun onConfigured(session: CameraCaptureSession) {
+                            captureSession = session
+                            try {
+                                val builder = device.createCaptureRequest(CameraDevice.TEMPLATE_RECORD)
+                                builder.addTarget(surface)
+                                session.setRepeatingRequest(builder.build(), null, backgroundHandler)
+                                mediaRecorder?.start()
+                                promise.resolve(null)
+                            } catch (e: Exception) {
+                                promise.reject("START_ERROR", e)
+                            }
+                        }
+
+                        override fun onConfigureFailed(session: CameraCaptureSession) {
+                            promise.reject("CONFIG_FAILED", "Configuration failed")
+                        }
+                    }, backgroundHandler)
+                }
+
+                override fun onDisconnected(device: CameraDevice) {
+                    promise.reject("DISCONNECTED", "Camera disconnected")
+                }
+
+                override fun onError(device: CameraDevice, error: Int) {
+                    promise.reject("CAMERA_ERROR", "Camera error: $error")
+                }
+            }, backgroundHandler)
+        } catch (e: Exception) {
+            promise.reject("ERROR", e)
+        }
+    }
+
+    @ReactMethod
+    fun stopStreaming(promise: Promise) {
+        try {
+            mediaRecorder?.apply {
+                stop()
+                reset()
+                release()
+            }
+            captureSession?.close()
+            cameraDevice?.close()
+            stopBackgroundThread()
+            mediaRecorder = null
+            captureSession = null
+            cameraDevice = null
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("STOP_ERROR", e)
+        }
+    }
+
+    private fun startBackgroundThread() {
+        backgroundThread = HandlerThread("CameraBackground").also { it.start() }
+        backgroundHandler = Handler(backgroundThread!!.looper)
+    }
+
+    private fun stopBackgroundThread() {
+        backgroundThread?.quitSafely()
+        backgroundThread = null
+        backgroundHandler = null
+    }
+}

--- a/android/app/src/main/java/com/rtpstreamer/CameraStreamerPackage.kt
+++ b/android/app/src/main/java/com/rtpstreamer/CameraStreamerPackage.kt
@@ -1,0 +1,16 @@
+package com.rtpstreamer
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class CameraStreamerPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(CameraStreamerModule(reactContext))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}

--- a/android/app/src/main/java/com/rtpstreamer/MainApplication.kt
+++ b/android/app/src/main/java/com/rtpstreamer/MainApplication.kt
@@ -9,6 +9,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.rtpstreamer.CameraStreamerPackage
 
 class MainApplication : Application(), ReactApplication {
 
@@ -18,6 +19,7 @@ class MainApplication : Application(), ReactApplication {
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:
               // add(MyReactNativePackage())
+              add(CameraStreamerPackage())
             }
 
         override fun getJSMainModuleName(): String = "index"


### PR DESCRIPTION
## Summary
- add `CameraStreamerModule` and register in `CameraStreamerPackage`
- register `CameraStreamerPackage` in `MainApplication`
- clean up `AndroidManifest` permissions
- replace FFmpeg usage in `App.tsx` with native module
- add stop-stream button
- update tests for new native module

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68540a385aa8832ba42d8bf7133835f1