### PR TITLE
Stream camera with ffmpeg

### DIFF
--- a/android/app/src/main/java/com/rtpstreamer/CameraStreamerModule.kt
+++ b/android/app/src/main/java/com/rtpstreamer/CameraStreamerModule.kt
@@ -1,113 +1,29 @@
 package com.rtpstreamer
 
-import android.content.Context
-import android.hardware.camera2.*
-import android.media.MediaRecorder
-import android.os.Handler
-import android.os.HandlerThread
-import com.facebook.react.bridge.*
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Promise
+import com.arthenica.ffmpegkit.FFmpegKit
+import com.arthenica.ffmpegkit.FFmpegSession
 
 class CameraStreamerModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
-    private var cameraDevice: CameraDevice? = null
-    private var captureSession: CameraCaptureSession? = null
-    private var mediaRecorder: MediaRecorder? = null
-    private var backgroundThread: HandlerThread? = null
-    private var backgroundHandler: Handler? = null
+    private var session: FFmpegSession? = null
 
     override fun getName() = "CameraStreamer"
 
     @ReactMethod
     fun startStreaming(promise: Promise) {
-        val activity = currentActivity ?: run {
-            promise.reject("NO_ACTIVITY", "Current activity is null")
-            return
-        }
-        val manager = activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-        try {
-            val cameraId = manager.cameraIdList.firstOrNull() ?: run {
-                promise.reject("NO_CAMERA", "No camera found")
-                return
-            }
-
-            startBackgroundThread()
-
-            mediaRecorder = MediaRecorder().apply {
-                setVideoSource(MediaRecorder.VideoSource.SURFACE)
-                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-                setVideoEncoder(MediaRecorder.VideoEncoder.H264)
-                setVideoSize(640, 480)
-                setVideoFrameRate(30)
-                setVideoEncodingBitRate(1_000_000)
-                setOutputFile("rtp://192.168.1.103:5002")
-                prepare()
-            }
-
-            val surface = mediaRecorder!!.surface
-
-            manager.openCamera(cameraId, object : CameraDevice.StateCallback() {
-                override fun onOpened(device: CameraDevice) {
-                    cameraDevice = device
-                    device.createCaptureSession(listOf(surface), object : CameraCaptureSession.StateCallback() {
-                        override fun onConfigured(session: CameraCaptureSession) {
-                            captureSession = session
-                            try {
-                                val builder = device.createCaptureRequest(CameraDevice.TEMPLATE_RECORD)
-                                builder.addTarget(surface)
-                                session.setRepeatingRequest(builder.build(), null, backgroundHandler)
-                                mediaRecorder?.start()
-                                promise.resolve(null)
-                            } catch (e: Exception) {
-                                promise.reject("START_ERROR", e)
-                            }
-                        }
-
-                        override fun onConfigureFailed(session: CameraCaptureSession) {
-                            promise.reject("CONFIG_FAILED", "Configuration failed")
-                        }
-                    }, backgroundHandler)
-                }
-
-                override fun onDisconnected(device: CameraDevice) {
-                    promise.reject("DISCONNECTED", "Camera disconnected")
-                }
-
-                override fun onError(device: CameraDevice, error: Int) {
-                    promise.reject("CAMERA_ERROR", "Camera error: $error")
-                }
-            }, backgroundHandler)
-        } catch (e: Exception) {
-            promise.reject("ERROR", e)
-        }
+        // Stream the first camera to the server using H264 over RTP
+        val command = "-f android_camera -video_size 640x480 -framerate 30 -i 0 -c:v libx264 -preset ultrafast -tune zerolatency -f rtp rtp://192.168.1.103:5002"
+        session = FFmpegKit.executeAsync(command)
+        promise.resolve(null)
     }
 
     @ReactMethod
     fun stopStreaming(promise: Promise) {
-        try {
-            mediaRecorder?.apply {
-                stop()
-                reset()
-                release()
-            }
-            captureSession?.close()
-            cameraDevice?.close()
-            stopBackgroundThread()
-            mediaRecorder = null
-            captureSession = null
-            cameraDevice = null
-            promise.resolve(null)
-        } catch (e: Exception) {
-            promise.reject("STOP_ERROR", e)
-        }
-    }
-
-    private fun startBackgroundThread() {
-        backgroundThread = HandlerThread("CameraBackground").also { it.start() }
-        backgroundHandler = Handler(backgroundThread!!.looper)
-    }
-
-    private fun stopBackgroundThread() {
-        backgroundThread?.quitSafely()
-        backgroundThread = null
-        backgroundHandler = null
+        session?.let { FFmpegKit.cancel(it.sessionId) }
+        session = null
+        promise.resolve(null)
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"
+        ffmpegKitPackage = "video"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary
- use FFmpegKit in native module to stream camera frames as H264 over RTP
- enable the ffmpeg-kit `video` package in Gradle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540ed4a0e4832b91abfd58501113f7